### PR TITLE
Copy libs on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN jlink --verbose --strip-java-debug-attributes --no-man-pages \
 java.security.jgss,java.security.sasl,java.sql.rowset,jdk.attach,jdk.httpserver,jdk.jdi,jdk.jfr,\
 jdk.management,jdk.net,jdk.unsupported,jdk.crypto.ec
 
-FROM gcr.io/distroless/java-base-debian11
+FROM debian:bullseye-slim
 WORKDIR /data/symphony
 COPY --from=0 /jre /jre
 COPY workflow-bot-app.jar app.jar
-COPY lib/wdk-studio.jar lib/wdk-studio.jar
-COPY lib/symphony-bdk-app-spring-boot-starter*.jar lib/bdk-app-starter.jar
+COPY lib/wdk-studio.jar staging/wdk-studio.jar
+COPY lib/symphony-bdk-app-spring-boot-starter*.jar staging/bdk-app-starter.jar
 COPY application.yaml application.yaml
-ENTRYPOINT [ "/jre/bin/java", "-jar", "app.jar", "--spring.profiles.active=prod" ]
+ENTRYPOINT [ \
+  "/bin/sh", "-c", \
+  "mkdir -p lib && cp staging/* lib/ && /jre/bin/java -jar app.jar --spring.profiles.active=prod" \
+]


### PR DESCRIPTION
* Copy libs on container startup to avoid k8s overwriting libs on volume mount